### PR TITLE
[CONSUL-682]Update ConsulIngressListener Struct

### DIFF
--- a/api/consul.go
+++ b/api/consul.go
@@ -447,6 +447,7 @@ type ConsulIngressListener struct {
 	Port     int                     `hcl:"port,optional"`
 	Protocol string                  `hcl:"protocol,optional"`
 	Services []*ConsulIngressService `hcl:"service,block"`
+	TLS      *ConsulGatewayTLSConfig `hcl:"tls,block"`
 }
 
 func (l *ConsulIngressListener) Canonicalize() {
@@ -462,6 +463,8 @@ func (l *ConsulIngressListener) Canonicalize() {
 	if len(l.Services) == 0 {
 		l.Services = nil
 	}
+
+	l.TLS.Canonicalize()
 }
 
 func (l *ConsulIngressListener) Copy() *ConsulIngressListener {
@@ -481,6 +484,7 @@ func (l *ConsulIngressListener) Copy() *ConsulIngressListener {
 		Port:     l.Port,
 		Protocol: l.Protocol,
 		Services: services,
+		TLS:      l.TLS.Copy(),
 	}
 }
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1567,6 +1567,7 @@ func apiConnectIngressListenerToStructs(in *api.ConsulIngressListener) *structs.
 		Port:     in.Port,
 		Protocol: in.Protocol,
 		Services: apiConnectIngressServicesToStructs(in.Services),
+		TLS:      apiConnectGatewayTLSConfig(in.TLS),
 	}
 }
 

--- a/jobspec/parse_service.go
+++ b/jobspec/parse_service.go
@@ -490,6 +490,7 @@ func parseConsulIngressListener(o *ast.ObjectItem) (*api.ConsulIngressListener, 
 		"port",
 		"protocol",
 		"service",
+		"tls",
 	}
 
 	if err := checkHCLKeys(o.Val, valid); err != nil {

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -1931,6 +1931,7 @@ type ConsulIngressListener struct {
 	Port     int
 	Protocol string
 	Services []*ConsulIngressService
+	TLS      *ConsulGatewayTLSConfig
 }
 
 func (l *ConsulIngressListener) Copy() *ConsulIngressListener {
@@ -1950,6 +1951,7 @@ func (l *ConsulIngressListener) Copy() *ConsulIngressListener {
 		Port:     l.Port,
 		Protocol: l.Protocol,
 		Services: services,
+		TLS:      l.TLS.Copy(),
 	}
 }
 
@@ -1963,6 +1965,10 @@ func (l *ConsulIngressListener) Equal(o *ConsulIngressListener) bool {
 	}
 
 	if l.Protocol != o.Protocol {
+		return false
+	}
+
+	if !l.TLS.Equal(o.TLS) {
 		return false
 	}
 


### PR DESCRIPTION
#Description

Added the `TLS` field to the ConsulIngressListener Struct and updated receiver functions in:

- `nomad/structs/services.go`
- `api/consul.go`

Updated the following functions:

- `apiConnectIngressListenerToStructs` in `command/agent/job_endpoint.go`
- `parseConsulIngressListener` in `jobspec/parse_service.go`
